### PR TITLE
Revert "fix(container): update image pgo to v5.6.1"

### DIFF
--- a/kubernetes/talos-maxi/apps/database/crunchy-postgres/app/helmrelease.yaml
+++ b/kubernetes/talos-maxi/apps/database/crunchy-postgres/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: pgo
-      version: 5.6.1
+      version: 5.6.0
       sourceRef:
         kind: HelmRepository
         name: crunchydata


### PR DESCRIPTION
Reverts frantathefranta/home-ops#304

Default images changed address from 
`registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.6.1-0` 
to  
`registry.developers.crunchydata.com/postgres-operator:ubi8-5.6.1-0` (doesn't resolve to anything)